### PR TITLE
Add permisions to upload index.yml files for the bundle role

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -47,6 +47,7 @@ export class Identities {
 
     props.buildBucket.grantRead(bundleRole, '*/dist/*');
     props.buildBucket.grantPut(bundleRole, '*/dist/*');
+    props.buildBucket.grantPut(bundleRole, '*/index.yml');
 
     props.buildBucket.grantRead(testRole, '*/dist/*');
     props.buildBucket.grantPut(testRole, '*/dist/*/tests/*');


### PR DESCRIPTION
Add permissions to upload index.yml files for the bundle role

The bundle role is the one used by the distribution-build jobs when
`vars/uploadArtifacts.groovy` is processes.  This change allows the
uploading/updating of index.yml files

Signed-off-by: Peter Nied <petern@amazon.com>